### PR TITLE
cuda-nvdisasm v12.9.88

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,9 @@ source:
   sha256: 955ba1f52f7115031f10408ce3cec4c745df41dba8fdf6024c3983d899e9fbbc  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
   script:
     - move bin\* %LIBRARY_BIN%  # [win]
 
@@ -57,11 +57,13 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: nvdisasm extracts information from standalone cubin files
   description: |
     nvdisasm extracts information from standalone cubin files and presents them in
     human readable format.
   doc_url: https://docs.nvidia.com/cuda/cuda-binary-utilities/
+  dev_url: https://docs.nvidia.com/cuda/cuda-binary-utilities/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-nvdisasm 12.9.88

**Destination channel:** defaults

### Links

- [PKG-12774](https://anaconda.atlassian.net/browse/PKG-12774) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds

[PKG-12774]: https://anaconda.atlassian.net/browse/PKG-12774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ